### PR TITLE
changed version and multi module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Liberty Dev Mode for VS Code
-A VS Code extension for liberty:dev mode. The extension will automatically run your Liberty Maven project in dev mode if it detects the `io.openliberty.tools:liberty-maven-plugin` or `boost.runtimes:openliberty`/`boost.runtimes:wlp` in the `pom.xml`. Through the Liberty Dev Dashboard explorer on the side bar, you can view all available Liberty dev projects in your workspace
+A VS Code extension for Liberty dev mode. The extension will automatically run your Liberty Maven project in dev mode if it detects the `io.openliberty.tools:liberty-maven-plugin` or `boost:boost-maven-plugin` in the `pom.xml`. Through the Liberty Dev Dashboard explorer on the side bar, you can view all available Liberty dev projects in your workspace.
 
 ## Quick Start
 - Install the extension
@@ -7,7 +7,7 @@ A VS Code extension for liberty:dev mode. The extension will automatically run y
 - Right-click a project in the Liberty Dev Dashboard to view the available commands
 
 ## Features
-- View supported `liberty-maven-plugin` or `boost.runtime:openliberty`/`boost.runtimes:wlp` projects in the workspace (must be of version `3.0.M1` or higher)
+- View supported `liberty-maven-plugin` or `boost-maven-plugin` projects in the workspace (must be of version `3.0.M1` or higher)
 - Start/Stop dev mode
 - Start dev mode with custom parameters
 - Run tests

--- a/README.md
+++ b/README.md
@@ -1,28 +1,17 @@
 # Liberty Dev Mode for VS Code
 A VS Code extension for liberty:dev mode. The extension will automatically run your Liberty Maven project in dev mode if it detects the `io.openliberty.tools:liberty-maven-plugin` or `boost.runtimes:openliberty`/`boost.runtimes:wlp` in the `pom.xml`. Through the Liberty Dev Dashboard explorer on the side bar, you can view all available Liberty dev projects in your workspace
 
+## Quick Start
+- Install the extension
+- Liberty Dev Mode supported projects will appear in the Liberty Dev Dashboard on the side bar
+- Right-click a project in the Liberty Dev Dashboard to view the available commands
+
 ## Features
-- View supported `liberty-maven-plugin` projects in the workspace (must be of version `3.0.M1` or higher)
+- View supported `liberty-maven-plugin` or `boost.runtime:openliberty`/`boost.runtimes:wlp` projects in the workspace (must be of version `3.0.M1` or higher)
 - Start/Stop dev mode
 - Start dev mode with custom parameters
 - Run tests
 - View unit and integration test reports
-
-## Installing the Extension
-
-- download the latest `liberty-dev-vscode-ext-0.x.vsix` file from [releases](https://github.com/OpenLiberty/liberty-dev-vscode-ext/releases)
-- from VS Code select `Install from vsix...` and select the `liberty-dev-vscode-ext-0.x.vsix` file
-
-### Generate and install the .vsix file
-- `git clone git@github.com:OpenLiberty/liberty-dev-vscode-ext.git`
-- navigate to the cloned `liberty-dev-vscode-ext` directory
-- `vsce package` to generate the `liberty-dev-vscode-ext-0.x.vsix` file
-- from VS Code select `Install from vsix...` and select the `liberty-dev-vscode-ext-0.x.vsix` file
-
-### Start the extension in debug mode
-- `git clone git@github.com:OpenLiberty/liberty-dev-vscode-ext.git`
-- navigate to the cloned `liberty-dev-vscode-ext` directory in VS Code
-- `F5` to launch the extension in debug mode
 
 ## Contributing
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "liberty-dev-vscode-ext",
 	"displayName": "Liberty Dev Extension",
 	"description": "VS Code extension for Liberty Dev mode",
-	"version": "0.1",
+	"version": "0.0.1",
 	"publisher": "Open Liberty",
 	"repository": {
 		"type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	if (workspaceFolders !== undefined) {
 		var allPomPaths: string[] = [];
 		for (let folder of workspaceFolders) {
-			var pomPaths: string[] = util.getAllPomPaths(folder);
+			var pomPaths: string[] = await util.getAllPomPaths(folder);
 			allPomPaths = allPomPaths.concat(pomPaths);
 		}
 

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,18 +1,10 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-export function getAllPomPaths(workspaceFolder: vscode.WorkspaceFolder): string[] {
-	const fs = require('fs');
-	const pomFileUris: string[] = [];
-
-	fs.readdirSync(workspaceFolder.uri.fsPath).forEach((file: string) => {
-		if (file === "pom.xml") {
-			pomFileUris.push(workspaceFolder.uri.fsPath + '/' + file);
-		}
-	});
-	
-	return pomFileUris;
-
+export async function getAllPomPaths(workspaceFolder: vscode.WorkspaceFolder):Promise<string[]> {
+	const pattern: string = "**/pom.xml";
+	const pomFileUris: vscode.Uri[] = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, pattern));
+	return pomFileUris.map(_uri => _uri.fsPath);
 }
 
 export function getReport(report: string) {

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -22,13 +22,7 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
         if (terminal !== undefined) {
             terminal.show();
             libProject.setTerminal(terminal);
-            var startCommand = "";
-            if (libProject.getBoost()) {
-                startCommand = 'mvn io.openliberty.tools:liberty-maven-plugin:RELEASE:dev -f "'
-            } else {
-                startCommand = 'mvn liberty:dev -f "'
-            }
-            terminal.sendText(startCommand + libProject.getPomPath() + '"'); // start dev mode on current project
+            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPomPath() + '"'); // start dev mode on current project
         }
     } else {
         console.error("Cannot start liberty:dev on an undefined project");
@@ -78,13 +72,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
                     ignoreFocusOut: true
                 }
             ));
-            var startCommand = "";
-            if (libProject.getBoost()) {
-                startCommand = 'mvn io.openliberty.tools:liberty-maven-plugin:RELEASE:dev '
-            } else {
-                startCommand = 'mvn liberty:dev '
-            }
-            terminal.sendText(startCommand + customCommand + ' -f "' + libProject.getPomPath() + '"');
+            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
         }
     } else {
         console.error("Cannot custom start liberty:dev on an undefined project");

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -22,7 +22,13 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
         if (terminal !== undefined) {
             terminal.show();
             libProject.setTerminal(terminal);
-            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPomPath() + '"'); // start dev mode on current project
+            var startCommand = "";
+            if (libProject.getBoost()) {
+                startCommand = 'mvn io.openliberty.tools:liberty-maven-plugin:RELEASE:dev -f "'
+            } else {
+                startCommand = 'mvn liberty:dev -f "'
+            }
+            terminal.sendText(startCommand + libProject.getPomPath() + '"'); // start dev mode on current project
         }
     } else {
         console.error("Cannot start liberty:dev on an undefined project");
@@ -72,7 +78,13 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
                     ignoreFocusOut: true
                 }
             ));
-            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
+            var startCommand = "";
+            if (libProject.getBoost()) {
+                startCommand = 'mvn io.openliberty.tools:liberty-maven-plugin:RELEASE:dev '
+            } else {
+                startCommand = 'mvn liberty:dev '
+            }
+            terminal.sendText(startCommand + customCommand + ' -f "' + libProject.getPomPath() + '"');
         }
     } else {
         console.error("Cannot custom start liberty:dev on an undefined project");

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -7,7 +7,7 @@ import { getReport } from './Util';
 
 // opens pom associated with LibertyProject and starts dev mode
 export async function openProject(pomPath: string): Promise<void> {
-    console.log("Opening pom.xml");
+    console.log("Opening " + pomPath);
     vscode.commands.executeCommand('vscode.open', vscode.Uri.file(pomPath));
 }
 
@@ -22,7 +22,7 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
         if (terminal !== undefined) {
             terminal.show();
             libProject.setTerminal(terminal);
-            terminal.sendText('mvn liberty:dev -f "' + libProject.getPomPath() + '"'); // start dev mode on current project
+            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev -f "' + libProject.getPomPath() + '"'); // start dev mode on current project
         }
     } else {
         console.error("Cannot start liberty:dev on an undefined project");
@@ -72,7 +72,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
                     ignoreFocusOut: true
                 }
             ));
-            terminal.sendText('mvn liberty:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
+            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
         }
     } else {
         console.error("Cannot custom start liberty:dev on an undefined project");

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -30,28 +30,38 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 
 	private async getProjectFromPom(pomPaths: string[]): Promise<LibertyProject[]> {
 		var projects: LibertyProject[] = [];
-		var parseString = require('xml2js').parseString;
+		var validPoms: String[] = [];
+		var modules: String[] = [];
+
+		// check for parentPoms
 		for (var pomPath of pomPaths) {
 			const xmlString: string = await fse.readFile(pomPath, "utf8");
-			var validPom = checkPom(xmlString);
-
-			if (validPom) {
-				var label = "";
-
-				parseString(xmlString, function (err: any, result: any) {
-					label = result.project.artifactId[0];
-				});
-				var project: LibertyProject = new LibertyProject(label, vscode.TreeItemCollapsibleState.None, pomPath, 'start', undefined, {
-					command: 'extension.open.project',
-					title: '',
-					arguments: [pomPath]
-				});
+			var validParent = checkParentPom(xmlString);
+			if (validParent) {
+				modules = modules.concat(findModules(xmlString));
+				var project = createProject(xmlString, pomPath);
 				projects.push(project);
+				validPoms.push(pomPath);
 			}
 		}
+
+		for (var pomPath of pomPaths) {
+			if (!validPoms.includes(pomPath)) {
+				const xmlString: string = await fse.readFile(pomPath, "utf8");
+				var validPom = checkPom(xmlString, modules);
+				if (validPom) {
+					var project = createProject(xmlString, pomPath);
+					projects.push(project);
+				}
+			}
+
+		}
+
 		return projects;
 	}
 }
+
+
 export class LibertyProject extends vscode.TreeItem {
 	constructor(
 		public readonly label: string,
@@ -101,24 +111,111 @@ export class LibertyProject extends vscode.TreeItem {
 		}
 		return undefined;
 	}
-
 	contextValue = 'liberty-dev-project';
 }
 
-export function checkPom(xmlString: String) {
+export function createProject(xmlString: String, pomPath: string) {
+	var label = "";
 	var parseString = require('xml2js').parseString;
-	var validPom = false;
 	parseString(xmlString, function (err: any, result: any) {
-		// check for open liberty or wlp boost runtime	
-		for (var ii = 0; ii < result.project.dependencies.length; ii++) {
-			for (var jj = 0; jj < result.project.dependencies[ii].dependency.length; jj++) {
-				var dependency = result.project.dependencies[ii].dependency[jj];
-				if (dependency.groupId[0] === "boost.runtimes" && (dependency.artifactId[0] === "openliberty" || dependency.artifactId[0] === "wlp")) {
-					console.debug("Found openliberty or wlp boost runtime in the pom");
-					validPom = true;
+		label = result.project.artifactId[0];
+	});
+	var project: LibertyProject = new LibertyProject(label, vscode.TreeItemCollapsibleState.None, pomPath, 'start', undefined, {
+		command: 'extension.open.project',
+		title: '',
+		arguments: [pomPath]
+	});
+	return project;
+}
+export function findModules(xmlString: String) {
+	var parseString = require('xml2js').parseString;
+	var children: String[] = [];
+	parseString(xmlString, function (err: any, result: any) {
+		var modules = result.project.modules;
+		if (modules !== undefined) {
+			for (var i = 0; i < modules.length; i++) {
+				var module = modules[i].module;
+				if (module !== undefined) {
+					for (var k = 0; k < module.length; k++) {
+						children.push(module[k]);
+					}
 				}
 			}
 		}
+
+		if (err) {
+			console.error("Error parsing the pom " + err);
+		}
+	});
+	return children;
+}
+export function checkParentPom(xmlString: String) {
+	var parseString = require('xml2js').parseString;
+	var parentPom = false;
+	parseString(xmlString, function (err: any, result: any) {
+		// check for open liberty or wlp boost runtime	
+		if (result.project.dependencies !== undefined) {
+			for (var ii = 0; ii < result.project.dependencies.length; ii++) {
+				for (var jj = 0; jj < result.project.dependencies[ii].dependency.length; jj++) {
+					var dependency = result.project.dependencies[ii].dependency[jj];
+					if (dependency.groupId[0] === "boost.runtimes" && (dependency.artifactId[0] === "openliberty" || dependency.artifactId[0] === "wlp")) {
+						console.debug("Found openliberty or wlp boost runtime in the pom");
+						parentPom = true;
+						return;
+					}
+				}
+			}
+		}
+
+		// check for liberty maven plugin in plugin management
+		for (var i = 0; i < result.project.build.length; i++) {
+			var pluginManagement = result.project.build[i].pluginManagement;
+			if (pluginManagement !== undefined) {
+				var plugins = pluginManagement[i].plugins;
+				if (plugins !== undefined) {
+					for (var j = 0; j < plugins.length; j++) {
+						var plugin = plugins[j].plugin;
+						if (plugin !== undefined) {
+							for (var k = 0; k < plugin.length; k++) {
+								if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
+									console.debug("Found liberty-maven-plugin in the pom plugin management");
+									parentPom = true;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if (err) {
+			console.error("Error parsing the pom " + err);
+		}
+	});
+	return parentPom;
+}
+
+export function checkPom(xmlString: String, modules: String[]) {
+	var parseString = require('xml2js').parseString;
+	var validPom = false;
+	parseString(xmlString, function (err: any, result: any) {
+		if (result.project.artifactId[0] !== undefined && modules.includes(result.project.artifactId[0])) {
+			validPom = true;
+			return;
+		}
+		// check for open liberty or wlp boost runtime	
+		if (result.project.dependencies !== undefined) {
+			for (var ii = 0; ii < result.project.dependencies.length; ii++) {
+				for (var jj = 0; jj < result.project.dependencies[ii].dependency.length; jj++) {
+					var dependency = result.project.dependencies[ii].dependency[jj];
+					if (dependency.groupId[0] === "boost.runtimes" && (dependency.artifactId[0] === "openliberty" || dependency.artifactId[0] === "wlp")) {
+						console.debug("Found openliberty or wlp boost runtime in the pom");
+						validPom = true;
+						return;
+					}
+				}
+			}
+		}
+
 		// check for liberty maven plugin
 		for (var i = 0; i < result.project.build.length; i++) {
 			var plugins = result.project.build[i].plugins;
@@ -128,17 +225,20 @@ export function checkPom(xmlString: String) {
 					if (plugin !== undefined) {
 						for (var k = 0; k < plugin.length; k++) {
 							console.debug(plugin[k]);
-							if (plugin[k].artifactId[0] === "liberty-maven-plugin") {
+							if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
 								console.debug("Found liberty-maven-plugin in the pom");
 								validPom = true; // no version specified, latest version downloaded from maven central
+								return;
 							}
 						}
 					}
 				}
 			}
 		}
+
 		if (err) {
 			console.error("Error parsing the pom " + err);
+			return;
 		}
 	});
 	return validPom;

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -167,33 +167,25 @@ export function checkParentPom(xmlString: String) {
 	var parentPom = false;
 	parseString(xmlString, function (err: any, result: any) {
 
-		// check for open liberty or wlp boost runtime	
-		if (result.project.dependencies !== undefined) {
-			for (var ii = 0; ii < result.project.dependencies.length; ii++) {
-				for (var jj = 0; jj < result.project.dependencies[ii].dependency.length; jj++) {
-					var dependency = result.project.dependencies[ii].dependency[jj];
-					if (dependency.groupId[0] === "boost.runtimes" && (dependency.artifactId[0] === "openliberty" || dependency.artifactId[0] === "wlp")) {
-						console.debug("Found openliberty or wlp boost runtime in the pom");
-						parentPom = true;
-						return;
-					}
-				}
-			}
-		}
-
 		// check for liberty maven plugin in plugin management
-		for (var i = 0; i < result.project.build.length; i++) {
-			var pluginManagement = result.project.build[i].pluginManagement;
-			if (pluginManagement !== undefined) {
-				var plugins = pluginManagement[i].plugins;
-				if (plugins !== undefined) {
-					for (var j = 0; j < plugins.length; j++) {
-						var plugin = plugins[j].plugin;
-						if (plugin !== undefined) {
-							for (var k = 0; k < plugin.length; k++) {
-								if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
-									console.debug("Found liberty-maven-plugin in the pom plugin management");
-									parentPom = true;
+		if (result.project.build !== undefined) {
+			for (var i = 0; i < result.project.build.length; i++) {
+				var pluginManagement = result.project.build[i].pluginManagement;
+				if (pluginManagement !== undefined) {
+					var plugins = pluginManagement[i].plugins;
+					if (plugins !== undefined) {
+						for (var j = 0; j < plugins.length; j++) {
+							var plugin = plugins[j].plugin;
+							if (plugin !== undefined) {
+								for (var k = 0; k < plugin.length; k++) {
+									if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
+										console.debug("Found liberty-maven-plugin in the pom.xml plugin management");
+										parentPom = true;
+									}
+									if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "boost") {
+										console.debug("Found boost-maven-plugin in the pom.xml");
+										parentPom = true;
+									}
 								}
 							}
 						}
@@ -201,6 +193,7 @@ export function checkParentPom(xmlString: String) {
 				}
 			}
 		}
+
 		if (err) {
 			console.error("Error parsing the pom " + err);
 		}
@@ -214,12 +207,12 @@ export function checkPom(xmlString: String, childrenMap: Map<string, String[]>) 
 	parseString(xmlString, function (err: any, result: any) {
 
 		// check if the artifactId matches one of the modules found in a parent pom
-		if (result.project.artifactId[0] !== undefined && result.project.parent[0].artifactId !== undefined) {
+		if (result.project.artifactId[0] !== undefined && result.project.parent !== undefined && result.project.parent[0].artifactId !== undefined) {
 			if (childrenMap.has(result.project.parent[0].artifactId[0])) {
 				var modules = childrenMap.get(result.project.parent[0].artifactId[0]);
 				if (modules !== undefined) {
 					for (let module of modules) {
-						if (module === result.project.artifactId[0]){
+						if (module === result.project.artifactId[0]) {
 							validPom = true;
 							return;
 						}
@@ -228,33 +221,25 @@ export function checkPom(xmlString: String, childrenMap: Map<string, String[]>) 
 			}
 		}
 
-		// check for open liberty or wlp boost runtime	
-		if (result.project.dependencies !== undefined) {
-			for (var ii = 0; ii < result.project.dependencies.length; ii++) {
-				for (var jj = 0; jj < result.project.dependencies[ii].dependency.length; jj++) {
-					var dependency = result.project.dependencies[ii].dependency[jj];
-					if (dependency.groupId[0] === "boost.runtimes" && (dependency.artifactId[0] === "openliberty" || dependency.artifactId[0] === "wlp")) {
-						console.debug("Found openliberty or wlp boost runtime in the pom");
-						validPom = true;
-						return;
-					}
-				}
-			}
-		}
-
 		// check for liberty maven plugin
-		for (var i = 0; i < result.project.build.length; i++) {
-			var plugins = result.project.build[i].plugins;
-			if (plugins !== undefined) {
-				for (var j = 0; j < plugins.length; j++) {
-					var plugin = result.project.build[i].plugins[j].plugin;
-					if (plugin !== undefined) {
-						for (var k = 0; k < plugin.length; k++) {
-							console.debug(plugin[k]);
-							if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
-								console.debug("Found liberty-maven-plugin in the pom");
-								validPom = true;
-								return;
+		if (result.project.build !== undefined) {
+			for (var i = 0; i < result.project.build.length; i++) {
+				var plugins = result.project.build[i].plugins;
+				if (plugins !== undefined) {
+					for (var j = 0; j < plugins.length; j++) {
+						var plugin = result.project.build[i].plugins[j].plugin;
+						if (plugin !== undefined) {
+							for (var k = 0; k < plugin.length; k++) {
+								if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] === "io.openliberty.tools") {
+									console.debug("Found liberty-maven-plugin in the pom.xml");
+									validPom = true;
+									return;
+								}
+								if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "boost") {
+									console.debug("Found boost-maven-plugin in the pom.xml");
+									validPom = true;
+									return;
+								}
 							}
 						}
 					}

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -37,9 +37,9 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 		for (var pomPath of pomPaths) {
 			const xmlString: string = await fse.readFile(pomPath, "utf8");
 			var validParent = checkParentPom(xmlString);
-			if (validParent) {
+			if (validParent[0]) {
 				childrenMap = new Map([...Array.from(childrenMap.entries()), ...Array.from(findModules(xmlString).entries())]);
-				var project = createProject(xmlString, pomPath);
+				var project = createProject(xmlString, pomPath, validParent[1]);
 				projects.push(project);
 				validPoms.push(pomPath);
 			}
@@ -49,8 +49,8 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 			if (!validPoms.includes(pomPath)) {
 				const xmlString: string = await fse.readFile(pomPath, "utf8");
 				var validPom = checkPom(xmlString, childrenMap);
-				if (validPom) {
-					var project = createProject(xmlString, pomPath);
+				if (validPom[0]) {
+					var project = createProject(xmlString, pomPath, validPom[1]);
 					projects.push(project);
 				}
 			}
@@ -68,6 +68,7 @@ export class LibertyProject extends vscode.TreeItem {
 		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
 		public readonly pomPath: string,
 		public state: string,
+		public boost: boolean,
 		public terminal?: vscode.Terminal,
 		public readonly command?: vscode.Command, // ? indicates optional param
 	) {
@@ -96,6 +97,10 @@ export class LibertyProject extends vscode.TreeItem {
 		return `${this.pomPath}`;
 	}
 
+	public getBoost() : boolean {
+		return this.boost;
+	}
+
 	public getTerminal(): vscode.Terminal | undefined {
 		return this.terminal;
 	}
@@ -114,13 +119,13 @@ export class LibertyProject extends vscode.TreeItem {
 	contextValue = 'liberty-dev-project';
 }
 
-export function createProject(xmlString: String, pomPath: string) {
+export function createProject(xmlString: String, pomPath: string, boost: boolean) {
 	var label = "";
 	var parseString = require('xml2js').parseString;
 	parseString(xmlString, function (err: any, result: any) {
 		label = result.project.artifactId[0];
 	});
-	var project: LibertyProject = new LibertyProject(label, vscode.TreeItemCollapsibleState.None, pomPath, 'start', undefined, {
+	var project: LibertyProject = new LibertyProject(label, vscode.TreeItemCollapsibleState.None, pomPath, 'start', boost, undefined, {
 		command: 'extension.open.project',
 		title: '',
 		arguments: [pomPath]
@@ -165,6 +170,7 @@ export function findModules(xmlString: String) {
 export function checkParentPom(xmlString: String) {
 	var parseString = require('xml2js').parseString;
 	var parentPom = false;
+	var boost = false;
 	parseString(xmlString, function (err: any, result: any) {
 
 		// check for liberty maven plugin in plugin management
@@ -185,6 +191,7 @@ export function checkParentPom(xmlString: String) {
 									if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "boost") {
 										console.debug("Found boost-maven-plugin in the pom.xml");
 										parentPom = true;
+										boost = true;
 									}
 								}
 							}
@@ -198,12 +205,13 @@ export function checkParentPom(xmlString: String) {
 			console.error("Error parsing the pom " + err);
 		}
 	});
-	return parentPom;
+	return [parentPom, boost];
 }
 
 export function checkPom(xmlString: String, childrenMap: Map<string, String[]>) {
 	var parseString = require('xml2js').parseString;
 	var validPom = false;
+	var boost = false;
 	parseString(xmlString, function (err: any, result: any) {
 
 		// check if the artifactId matches one of the modules found in a parent pom
@@ -238,6 +246,7 @@ export function checkPom(xmlString: String, childrenMap: Map<string, String[]>) 
 								if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "boost") {
 									console.debug("Found boost-maven-plugin in the pom.xml");
 									validPom = true;
+									boost = true;
 									return;
 								}
 							}
@@ -252,5 +261,5 @@ export function checkPom(xmlString: String, childrenMap: Map<string, String[]>) 
 			return;
 		}
 	});
-	return validPom;
+	return [validPom, boost];
 }


### PR DESCRIPTION
Support multi module project by:
- checking for boost runtime or liberty maven plugin in plugin management
- if the above exists, check and store modules listed in that pom
- check the other `pom.xml` files in the workspace and see if either their `artifactId` matches one of the previously stored modules or if they have the boost runtime or liberty maven plugin.

The plugin will display the parent `pom.xml`, modules of the parent `pom.xml`, and additional `pom.xml` files with the liberty maven plugin or boost runtime configured