### PR TITLE
liberty.terminal.useJavaHome introduced to use configured java.home

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,10 @@ A VS Code extension for Liberty dev mode. The extension will detect your Liberty
 - Run tests
 - View unit and integration test reports
 
+## Configurable User Settings
+| Setting | Description | Default Value |
+| --------  | ----------- | -------  |
+| liberty.terminal.useJavaHome | If this value is true, and if the setting `java.home` from the redhat extension has a value, then the environment variable `JAVA_HOME` will be set to the value of `java.home` when a new terminal window is created. | False |
+
 ## Contributing
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A VS Code extension for Liberty dev mode. The extension will detect your Liberty
 ## Configurable User Settings
 | Setting | Description | Default Value |
 | --------  | ----------- | -------  |
-| liberty.terminal.useJavaHome | If this value is true, and if the setting `java.home` from the redhat extension has a value, then the environment variable `JAVA_HOME` will be set to the value of `java.home` when a new terminal window is created. | False |
+| liberty.terminal.useJavaHome | If this value is true, and if the setting `java.home` has a value, then the environment variable `JAVA_HOME` will be set to the value of `java.home` when a new terminal window is created. | False |
 
 ## Contributing
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.

--- a/package.json
+++ b/package.json
@@ -93,7 +93,20 @@
 					"when": "viewItem == liberty-dev-project"
 				}
 			]
-		}
+		},
+		"configuration": [
+			{
+				"title": "Liberty Dev",
+				"properties": {
+				  "liberty.terminal.useJavaHome": {
+					"type": "boolean",
+					"default": false,
+					"description": "If this value is true, and if the setting java.home from the redhat extension has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+					"scope": "window"
+				  }
+				}
+			  }
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 				  "liberty.terminal.useJavaHome": {
 					"type": "boolean",
 					"default": false,
-					"description": "If this value is true, and if the setting java.home from the redhat extension has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+					"description": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
 					"scope": "window"
 				  }
 				}

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,13 +1,23 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-export async function getAllPomPaths(workspaceFolder: vscode.WorkspaceFolder):Promise<string[]> {
+export async function getAllPomPaths(workspaceFolder: vscode.WorkspaceFolder): Promise<string[]> {
 	const pattern: string = "**/pom.xml";
 	const pomFileUris: vscode.Uri[] = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, pattern));
 	return pomFileUris.map(_uri => _uri.fsPath);
 }
 
 export function getReport(report: string) {
-    var file = fs.readFileSync(report, 'utf8');
-    return file;
+	var file = fs.readFileSync(report, 'utf8');
+	return file;
+}
+
+export function getConfiguration<T>(section: string, resourceOrFilepath?: vscode.Uri | string): T | undefined {
+	let resource: vscode.Uri | undefined;
+	if (typeof resourceOrFilepath === "string") {
+		resource = vscode.Uri.file(resourceOrFilepath);
+	} else if (resourceOrFilepath instanceof vscode.Uri) {
+		resource = resourceOrFilepath;
+	}
+	return vscode.workspace.getConfiguration("liberty", resource).get<T>(section);
 }

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -72,7 +72,9 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
                     ignoreFocusOut: true
                 }
             ));
-            terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
+            if (customCommand !== undefined) {
+                terminal.sendText('mvn io.openliberty.tools:liberty-maven-plugin:dev ' + customCommand + ' -f "' + libProject.getPomPath() + '"');
+            }
         }
     } else {
         console.error("Cannot custom start liberty:dev on an undefined project");

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as fse from "fs-extra";
+import * as util from './Util';
 
 export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> {
 
@@ -106,7 +107,16 @@ export class LibertyProject extends vscode.TreeItem {
 
 	public createTerminal(): vscode.Terminal | undefined {
 		if (this.terminal === undefined) {
-			var terminal = vscode.window.createTerminal(this.label + " (liberty:dev)");
+			// configure terminal to use java.home if liberty.terminal.useJavaHome is true
+			const useJavaHome: any = util.getConfiguration("terminal.useJavaHome");
+			var env: { [envKey: string]: string } = {};
+			if (useJavaHome) {
+				const javaHome: string | undefined = vscode.workspace.getConfiguration("java").get<string>("home");
+				if (javaHome) {
+					env = {JAVA_HOME: javaHome };
+				}
+			}
+			var terminal = vscode.window.createTerminal({name: this.label + " (liberty:dev)", env: env});
 			return terminal;
 		}
 		return undefined;


### PR DESCRIPTION
added support to honour `java.home` user setting with `liberty.terminal.useJavaHome`

Fix for https://github.com/OpenLiberty/liberty-dev-vscode-ext/issues/9