### PR TITLE
remove liberty.dev commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,32 @@
 					"command": "liberty.dev.open.surefire.report",
 					"when": "viewItem == liberty-dev-project"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "liberty.dev.start",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.stop",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.custom",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.run.tests",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.open.failsafe.report",
+					"when": "never"
+				},
+				{
+					"command": "liberty.dev.open.surefire.report",
+					"when": "never"
+				}
 			]
 		},
 		"configuration": [


### PR DESCRIPTION
Fix for #17 
Prevent the Liberty dev commands from showing up in the command palette, instead, they can only be triggered from the Liberty dev explorer view. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>