### PR TITLE
update test report does not exist error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,27 +70,27 @@
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				},
 				{
 					"command": "liberty.dev.stop",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				},
 				{
 					"command": "liberty.dev.custom",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				},
 				{
 					"command": "liberty.dev.run.tests",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				},
 				{
 					"command": "liberty.dev.open.failsafe.report",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				},
 				{
 					"command": "liberty.dev.open.surefire.report",
-					"when": "viewItem == liberty-dev-project"
+					"when": "viewItem == libertyProject"
 				}
 			],
 			"commandPalette": [

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -115,7 +115,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
                     );
                     panel.webview.html = getReport(report); // display HTML content
                 } else {
-                    vscode.window.showInformationMessage("Test report does not exist");
+                    vscode.window.showInformationMessage("Test report (" + report + ") does not exist.  Run tests to generate a test report.");
                 }
             });
         }
@@ -123,5 +123,3 @@ export async function openReport(reportType: string, libProject?: LibertyProject
         console.error("Cannot open test reports on an undefined project");
     }
 }
-
-

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -121,7 +121,7 @@ export class LibertyProject extends vscode.TreeItem {
 		}
 		return undefined;
 	}
-	contextValue = 'liberty-dev-project';
+	contextValue = 'libertyProject';
 }
 
 export function createProject(xmlString: String, pomPath: string) {


### PR DESCRIPTION
Fix for #20

Improve the error message when a test report does not exist to make it clear to the user that they need to run tests to generate a report.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>