### PR TITLE
Add liberty-gradle-plugin support to the extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Liberty Tools for VS Code
-A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with Liberty dev mode on all available [Liberty Maven](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) or [Liberty Gradle](https://github.com/OpenLiberty/ci.gradle/blob/master/docs/libertyDev.md) in your workspace.
+A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with Liberty dev mode on all available [Liberty Maven](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) or [Liberty Gradle](https://github.com/OpenLiberty/ci.gradle/blob/master/docs/libertyDev.md) projects in your workspace.
 
 ## Quick Start
 - Install the extension
@@ -7,7 +7,7 @@ A VS Code extension for Open Liberty. The extension will detect your Liberty Mav
 - Right-click a project in the Liberty Dev Dashboard to view the available commands
 
 ## Features
-- View supported `liberty-maven-plugin` (version `3.1` or higher) or `liberty-gradle-plugin`(versoin `3.0` or higher) projects in the workspace
+- View supported `liberty-maven-plugin` (version `3.1` or higher) or `liberty-gradle-plugin`(version `3.0` or higher) projects in the workspace
 - Start/Stop dev mode
 - Start dev mode with custom parameters
 - Run tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Liberty Tools for VS Code
-A VS Code extension for Open Liberty. The extension will detect your Liberty Maven project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml`. Through the Liberty Dev Dashboard, you can start, stop, or interact with [Liberty dev mode](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) on all available Liberty Maven projects in your workspace.
+A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with [Liberty dev mode](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) on all available Liberty Maven or Liberty Gradle projects in your workspace.
 
 ## Quick Start
 - Install the extension
@@ -7,7 +7,7 @@ A VS Code extension for Open Liberty. The extension will detect your Liberty Mav
 - Right-click a project in the Liberty Dev Dashboard to view the available commands
 
 ## Features
-- View supported `liberty-maven-plugin` projects in the workspace (`liberty-maven-plugin` should be of version `3.1` or higher)
+- View supported `liberty-maven-plugin` or `liberty-gradle-plugin` projects in the workspace (`liberty-maven-plugin` should be of version `3.1` or higher)
 - Start/Stop dev mode
 - Start dev mode with custom parameters
 - Run tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Liberty Tools for VS Code
-A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with [Liberty dev mode](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) on all available Liberty Maven or Liberty Gradle projects in your workspace.
+A VS Code extension for Open Liberty. The extension will detect your Liberty Maven or Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or `io.openliberty.tools:liberty-gradle-plugin` in the `build.gradle`. Through the Liberty Dev Dashboard, you can start, stop, or interact with Liberty dev mode on all available [Liberty Maven](https://github.com/OpenLiberty/ci.maven/blob/master/docs/dev.md#dev) or [Liberty Gradle](https://github.com/OpenLiberty/ci.gradle/blob/master/docs/libertyDev.md) in your workspace.
 
 ## Quick Start
 - Install the extension
@@ -7,7 +7,7 @@ A VS Code extension for Open Liberty. The extension will detect your Liberty Mav
 - Right-click a project in the Liberty Dev Dashboard to view the available commands
 
 ## Features
-- View supported `liberty-maven-plugin` or `liberty-gradle-plugin` projects in the workspace (`liberty-maven-plugin` should be of version `3.1` or higher)
+- View supported `liberty-maven-plugin` (version `3.1` or higher) or `liberty-gradle-plugin`(versoin `3.0` or higher) projects in the workspace
 - Start/Stop dev mode
 - Start dev mode with custom parameters
 - Run tests

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"onCommand:liberty.dev.run.tests",
 		"onCommand:liberty.dev.open.failsafe.report",
 		"onCommand:liberty.dev.open.surefire.report",
+		"onCommand:liberty.dev.open.gradle.test.report",
 		"onView:liberty-dev"
 	],
 	"main": "./out/extension.js",
@@ -71,33 +72,42 @@
 				"command": "liberty.dev.open.surefire.report",
 				"category": "Open Liberty",
 				"title": "View unit test report"
+			},
+			{
+				"command": "liberty.dev.open.gradle.test.report",
+				"category": "Open Liberty",
+				"title": "View test report"
 			}
 		],
 		"menus": {
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
 				},
 				{
 					"command": "liberty.dev.stop",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
 				},
 				{
 					"command": "liberty.dev.custom",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
 				},
 				{
 					"command": "liberty.dev.run.tests",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
 				},
 				{
 					"command": "liberty.dev.open.failsafe.report",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject"
 				},
 				{
 					"command": "liberty.dev.open.surefire.report",
-					"when": "viewItem == libertyProject"
+					"when": "viewItem == libertyMavenProject"
+				},
+				{
+					"command": "liberty.dev.open.gradle.test.report",
+					"when": "viewItem == libertyGradleProject"
 				}
 			],
 			"commandPalette": [
@@ -124,6 +134,10 @@
 				{
 					"command": "liberty.dev.open.surefire.report",
 					"when": "never"
+				},
+				{
+					"command": "liberty.dev.open.gradle.test.report",
+					"when": "never"
 				}
 			]
 		},
@@ -131,14 +145,14 @@
 			{
 				"title": "Liberty Dev",
 				"properties": {
-				  "liberty.terminal.useJavaHome": {
-					"type": "boolean",
-					"default": false,
-					"description": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
-					"scope": "window"
-				  }
+					"liberty.terminal.useJavaHome": {
+						"type": "boolean",
+						"default": false,
+						"description": "If this value is true, and if the setting java.home has a value, then the environment variable JAVA_HOME will be set to the value of java.home when a new terminal window is created.",
+						"scope": "window"
+					}
 				}
-			  }
+			}
 		]
 	},
 	"scripts": {
@@ -163,6 +177,7 @@
 		"@types/fs-extra": "^8.0.0",
 		"@types/xml2js": "^0.4.4",
 		"fs-extra": "^8.1.0",
+		"gradle-to-js": "^2.0.0",
 		"xml2js": "^0.4.19"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,18 +10,27 @@ export async function activate(context: vscode.ExtensionContext) {
 	const workspaceFolders = vscode.workspace.workspaceFolders;
 	if (workspaceFolders !== undefined) {
 		var allPomPaths: string[] = [];
+		var allGradlePaths: string[] = [];
 		for (let folder of workspaceFolders) {
-			var pomPaths: string[] = await util.getAllPomPaths(folder);
+			var pomPaths: string[] = await util.getAllPaths(folder, "**/pom.xml");
+			var gradlePaths: string[] = await util.getAllPaths(folder, "**/build.gradle");
 			allPomPaths = allPomPaths.concat(pomPaths);
+			allGradlePaths = allGradlePaths.concat(gradlePaths);
 		}
 
-		if (vscode.workspace.rootPath !== undefined) {
-			const projectProvider = new ProjectProvider(vscode.workspace.rootPath, allPomPaths);
+		if (vscode.workspace.workspaceFolders !== undefined) {
+			const projectProvider = new ProjectProvider(vscode.workspace.workspaceFolders, allPomPaths, allGradlePaths);
 			vscode.window.registerTreeDataProvider('liberty-dev', projectProvider);
 			vscode.workspace.onDidChangeTextDocument((e) => {
 				pomPaths.forEach((pom) => {
 					console.log("pom: " + pom);
 					if (pom === e.document.uri.fsPath) {
+						projectProvider.refresh();
+					}
+				});
+				gradlePaths.forEach((gradlePath) => {
+					console.log("gradlePath: " + gradlePath);
+					if (gradlePath === e.document.uri.fsPath) {
 						projectProvider.refresh();
 					}
 				});
@@ -36,7 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.stop', async (libProject?: LibertyProject | undefined) => devCommands.stopDevMode(libProject))
-	);
+	);LibertyProject
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.custom', async (libProject?: LibertyProject | undefined) => devCommands.customDevMode(libProject))
 	);
@@ -48,6 +57,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.open.surefire.report', async (libProject?: LibertyProject | undefined) => devCommands.openReport('surefire', libProject))
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand('liberty.dev.open.gradle.test.report', async (libProject?: LibertyProject | undefined) => devCommands.openReport('gradle', libProject))
 	);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,13 +23,11 @@ export async function activate(context: vscode.ExtensionContext) {
 			vscode.window.registerTreeDataProvider('liberty-dev', projectProvider);
 			vscode.workspace.onDidChangeTextDocument((e) => {
 				pomPaths.forEach((pom) => {
-					console.log("pom: " + pom);
 					if (pom === e.document.uri.fsPath) {
 						projectProvider.refresh();
 					}
 				});
 				gradlePaths.forEach((gradlePath) => {
-					console.log("gradlePath: " + gradlePath);
 					if (gradlePath === e.document.uri.fsPath) {
 						projectProvider.refresh();
 					}
@@ -45,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.stop', async (libProject?: LibertyProject | undefined) => devCommands.stopDevMode(libProject))
-	);LibertyProject
+	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.custom', async (libProject?: LibertyProject | undefined) => devCommands.customDevMode(libProject))
 	);

--- a/src/utils/GradleUtil.ts
+++ b/src/utils/GradleUtil.ts
@@ -1,0 +1,120 @@
+import * as path from 'path';
+import * as fse from "fs-extra";
+import { settings } from 'cluster';
+
+/**
+ * Check a build.gradle file for the liberty-gradle-plugin
+ * Return true if the build.gradle contains applies the liberty plugin
+ * @param buildFile JS object representation of the build.gradle
+ */
+export function validGradleBuild(buildFile: any) {
+    if (buildFile !== undefined) {
+        if (buildFile.apply !== undefined && buildFile.buildscript !== undefined && buildFile.buildscript.dependencies !== undefined) {
+            // check that "apply plugin: 'liberty'" is specified in the build.gradle
+            var libertyPlugin = false;
+            for (var i = 0; i < buildFile.apply.length; i++) {
+                if (buildFile.apply[i] == "plugin: 'liberty'") {
+                    libertyPlugin = true;
+                }
+            }
+            if (libertyPlugin) {
+                for (var i = 0; i < buildFile.buildscript.dependencies.length; i++) {
+                    var dependency = buildFile.buildscript.dependencies[i];
+                    // check that group matches io.openliberty.tools and name matches liberty-gradle-plugin
+                    if (dependency.group == "io.openliberty.tools" && dependency.name == "liberty-gradle-plugin") {
+                        console.debug("Found liberty-gradle-plugin in the build.gradle");
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Get the name of a gradle project
+ * If a settings.gradle exists with a name specified, return name
+ * Else return the parent directory name of the build.gradle
+ * @param path build.gradle location
+ */
+export async function getGradleProjetName(gradlePath: string): Promise<string> {
+    var dirName = path.dirname(gradlePath);
+    var gradleSettings = getGradleSettings(gradlePath);
+    var label = path.basename(dirName);
+    if (fse.existsSync(gradleSettings)) {
+        // File exists in path
+        var g2js = require('gradle-to-js/lib/parser');
+        label = await g2js.parseFile(gradleSettings).then(function (representation: any) {
+            if (representation["rootProject.name"] !== undefined) {
+                return representation["rootProject.name"];
+            }
+        }).catch((err: any) => console.error("Unable to parse settings.gradle: " + gradleSettings + "; " + err));
+    }
+    return label;
+}
+
+/**
+ * Get settings.gradle associated with a build.gradle
+ * Look in same directory as build.gradle or a child-folder
+ * with the directory name "master"
+ * @param gradlePath
+ */
+export function getGradleSettings(gradlePath: string): string {
+    var dirName = path.dirname(gradlePath);
+    var gradleSettings = path.normalize(path.join(dirName, "settings.gradle"));
+    if (fse.existsSync(gradleSettings)) {
+        // settings.gradle exists in same directory as build.gradle
+        return gradleSettings;
+    } else {
+        gradleSettings = path.normalize(path.join(dirName, "master", "settings.gradle"));
+        if (fse.existsSync(gradleSettings)) {
+            // settings.gradle exists in /master directory
+            return gradleSettings;
+        }
+    }
+
+    // return empty string if settings.gradle could not be found
+    return "";
+}
+
+
+/**
+ * Given a settings.gradle file, determine if there are valid child gradle projects
+ * The parent build.gradle must have subprojects in the `include` section and 
+ * apply the liberty-gradle-plugin to the subprojects
+ * Returns children associated with the parent build.gradle
+ * @param settingsFile settings.gradle file
+ */
+export function findChildGradleProjects(buildFile: any, settingsFile: any): string[] {
+    var gradleChildren: string[] = new Array();
+    var validGradleChildren: string[] = new Array();
+    if (settingsFile !== undefined) {
+        // look for a valid "include" section in the settingsFile
+        if (settingsFile.include !== undefined) {
+            if (typeof settingsFile.include === "string") {
+                // strip quotations and spaces from "include" string
+                let subprojects = settingsFile.include.replace(/['" ]+/g, '');
+                gradleChildren = subprojects.split(',');
+            } else {
+                for (var i = 0; i < settingsFile.include.length; i++) {
+                    gradleChildren.push(settingsFile.include[i]);
+                }
+            }
+        }
+    }
+
+    // check if the liberty-gradle-plugin is applied to any/all of the subprojects
+    if (gradleChildren.length !== 0) {
+        validGradleChildren = validParent(buildFile, gradleChildren);
+    }
+    return validGradleChildren;
+}
+
+function validParent(buildFile: any, gradleChildren: string[]): string[] {
+    // every subproject listed in the include section of the parent is supported by the liberty-gradle-plugin
+    if (validGradleBuild(buildFile.subprojects) || validGradleBuild(buildFile.allprojects)) {
+        return gradleChildren;
+    }
+    return new Array();
+}

--- a/src/utils/GradleUtil.ts
+++ b/src/utils/GradleUtil.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as fse from "fs-extra";
-import { settings } from 'cluster';
 
 /**
  * Check a build.gradle file for the liberty-gradle-plugin
@@ -8,23 +7,22 @@ import { settings } from 'cluster';
  * @param buildFile JS object representation of the build.gradle
  */
 export function validGradleBuild(buildFile: any) {
-    if (buildFile !== undefined) {
-        if (buildFile.apply !== undefined && buildFile.buildscript !== undefined && buildFile.buildscript.dependencies !== undefined) {
-            // check that "apply plugin: 'liberty'" is specified in the build.gradle
-            var libertyPlugin = false;
-            for (var i = 0; i < buildFile.apply.length; i++) {
-                if (buildFile.apply[i] == "plugin: 'liberty'") {
-                    libertyPlugin = true;
-                }
+    if (buildFile !== undefined && buildFile.apply !== undefined && buildFile.buildscript !== undefined && buildFile.buildscript.dependencies !== undefined) {
+        // check that "apply plugin: 'liberty'" is specified in the build.gradle
+        var libertyPlugin = false;
+        for (var i = 0; i < buildFile.apply.length; i++) {
+            if (buildFile.apply[i] == "plugin: 'liberty'") {
+                libertyPlugin = true;
+                break;
             }
-            if (libertyPlugin) {
-                for (var i = 0; i < buildFile.buildscript.dependencies.length; i++) {
-                    var dependency = buildFile.buildscript.dependencies[i];
-                    // check that group matches io.openliberty.tools and name matches liberty-gradle-plugin
-                    if (dependency.group == "io.openliberty.tools" && dependency.name == "liberty-gradle-plugin") {
-                        console.debug("Found liberty-gradle-plugin in the build.gradle");
-                        return true;
-                    }
+        }
+        if (libertyPlugin) {
+            for (var i = 0; i < buildFile.buildscript.dependencies.length; i++) {
+                var dependency = buildFile.buildscript.dependencies[i];
+                // check that group matches io.openliberty.tools and name matches liberty-gradle-plugin
+                if (dependency.group == "io.openliberty.tools" && dependency.name == "liberty-gradle-plugin") {
+                    console.debug("Found liberty-gradle-plugin in the build.gradle");
+                    return true;
                 }
             }
         }

--- a/src/utils/MavenUtil.ts
+++ b/src/utils/MavenUtil.ts
@@ -1,0 +1,167 @@
+/**
+ * Look for a valid parent pom.xml
+ * A valid parent contains the liberty-maven-plguin in the plugin management section
+ * Return true if the pom is a valid parent pom.xml
+ * @param xmlString the xmlString version of the pom.xml
+ */
+export function validParentPom(xmlString: String) {
+    var parseString = require('xml2js').parseString;
+    var parentPom = false;
+    parseString(xmlString, function (err: any, result: any) {
+
+        // check for liberty maven plugin or boost maven plugin in plugin management
+        if (result.project.build !== undefined) {
+            for (var i = 0; i < result.project.build.length; i++) {
+                var pluginManagement = result.project.build[i].pluginManagement;
+                if (pluginManagement !== undefined) {
+                    var plugins = pluginManagement[i].plugins;
+                    if (plugins !== undefined) {
+                        for (var j = 0; j < plugins.length; j++) {
+                            var plugin = plugins[j].plugin;
+                            if (plugin !== undefined) {
+                                for (var k = 0; k < plugin.length; k++) {
+                                    if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] == "io.openliberty.tools") {
+                                        console.debug("Found liberty-maven-plugin in the pom.xml plugin management");
+                                        parentPom = true;
+                                    }
+                                    if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "org.microshed.boost") {
+                                        console.debug("Found boost-maven-plugin in the pom.xml");
+                                        parentPom = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (err) {
+            console.error("Error parsing the pom " + err);
+        }
+    });
+    return parentPom;
+}
+
+/**
+ * Check a pom.xml to see if it contains the liberty-maven-plugin
+ * Pom.xml may either match a child pom artifactId, contain the plugin in the profiles section
+ * or define the plugin in the build section
+ * Return true if the pom.xml contains the plugin
+ * @param xmlString string representation of the pom.xml
+ * @param childrenMap map of all the children pom.xml identified
+ */
+export function validPom(xmlString: String, childrenMap: Map<string, String[]>) {
+    var parseString = require('xml2js').parseString;
+    var validPom = false;
+    parseString(xmlString, function (err: any, result: any) {
+
+        // check if the artifactId matches one of the modules found in a parent pom
+        if (result.project.artifactId[0] !== undefined && result.project.parent !== undefined && result.project.parent[0].artifactId !== undefined) {
+            if (childrenMap.has(result.project.parent[0].artifactId[0])) {
+                var modules = childrenMap.get(result.project.parent[0].artifactId[0]);
+                if (modules !== undefined) {
+                    for (let module of modules) {
+                        if (module === result.project.artifactId[0]) {
+                            validPom = true;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        // check for liberty maven plugin in profiles
+        if (result.project.profiles !== undefined) {
+            for (var i = 0; i < result.project.profiles.length; i++) {
+                var profile = result.project.profiles[i].profile;
+                if (profile !== undefined) {
+                    for (var j = 0; j < profile.length; j++) {
+                        if (mavenPluginDetected(profile[j].build)) {
+                            validPom = true;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        // check for liberty maven plugin in plugins 
+        if (mavenPluginDetected(result.project.build)) {
+            validPom = true;
+            return;
+        }
+
+        if (err) {
+            console.error("Error parsing the pom " + err);
+            return;
+        }
+    });
+    return validPom;
+}
+
+/**
+ * Check the build portion of a pom.xml for the liberty-maven-plugin
+ * Return true if the liberty-maven-plugin is found
+ * @param build JS object of the build section in a pom.xml
+ */
+function mavenPluginDetected(build: { plugins: { plugin: any; }[]; }[] | undefined) {
+    if (build !== undefined) {
+        for (var i = 0; i < build.length; i++) {
+            var plugins = build[i].plugins;
+            if (plugins !== undefined) {
+                for (var j = 0; j < plugins.length; j++) {
+                    var plugin = build[i].plugins[j].plugin;
+                    if (plugin !== undefined) {
+                        for (var k = 0; k < plugin.length; k++) {
+                            if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] === "io.openliberty.tools") {
+                                console.debug("Found liberty-maven-plugin in the pom.xml");
+                                return true;
+                            }
+                            if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "org.microshed.boost") {
+                                console.debug("Found boost-maven-plugin in the pom.xml");
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Given a parent pom find the corresponding child modules
+ * @param xmlString parent pom.xml
+ */
+export function findChildMavenModules(xmlString: String): Map<string, String[]> {
+    var parseString = require('xml2js').parseString;
+    var childrenMap: Map<string, String[]> = new Map();
+    var children: String[] = [];
+    parseString(xmlString, function (err: any, result: any) {
+        var artifactId = "";
+        if (result.project.artifactId[0] !== undefined) {
+            artifactId = result.project.artifactId[0];
+        }
+        var modules = result.project.modules;
+        if (modules !== undefined && artifactId !== undefined) {
+            for (var i = 0; i < modules.length; i++) {
+                var module = modules[i].module;
+                if (module !== undefined) {
+                    for (var k = 0; k < module.length; k++) {
+                        children.push(module[k]);
+                    }
+                }
+            }
+        }
+
+        if (children.length !== 0) {
+            childrenMap.set(artifactId, children);
+        }
+
+        if (err) {
+            console.error("Error parsing the pom " + err);
+        }
+    });
+    return childrenMap;
+}

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 export async function getAllPaths(workspaceFolder: vscode.WorkspaceFolder, pattern: string) : Promise<string[]> {
-	const pomFileUris: vscode.Uri[] = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, pattern));
-	return pomFileUris.map(_uri => _uri.fsPath);
+	const fileUris: vscode.Uri[] = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, pattern),'**/{bin,classes,target}/**');
+	return fileUris.map(_uri => _uri.fsPath);
 }
 
 export function getReport(report: string) {

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-export async function getAllPomPaths(workspaceFolder: vscode.WorkspaceFolder): Promise<string[]> {
-	const pattern: string = "**/pom.xml";
+export async function getAllPaths(workspaceFolder: vscode.WorkspaceFolder, pattern: string) : Promise<string[]> {
 	const pomFileUris: vscode.Uri[] = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, pattern));
 	return pomFileUris.map(_uri => _uri.fsPath);
 }

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -116,7 +116,7 @@ export async function runTests(libProject?: LibertyProject | undefined): Promise
     }
 }
 
-// open surefire or failsafe test report
+// open surefire, failsafe, or gradle test report
 export async function openReport(reportType: string, libProject?: LibertyProject | undefined): Promise<void> {
     if (libProject !== undefined) {
         console.log("Opening test reports for " + libProject.getLabel());


### PR DESCRIPTION
The extension will detect a liberty-gradle-project if:
1. `apply plugin: 'liberty'` and `io.openliberty.tools:liberty-gradle-plugin` is in the classpath in the `buildscript` block of the `build.gradle`
2. For multi-level projects, the plugin will list all subprojects in the `include` block of a parent's `settings.gradle` if the plugin is found in the `subprojects` or `allprojects` block of a parent's `build.gradle`. See #26.

In the explorer view of the dashboard, the project will either be named using the `rootProject.name=` setting in the `settings.gradle`, if that does not exist, it will be named after the directory name that the `build.gradle` is in.  The `settings.gradle` may be either in the same directory as the `build.gradle` or in a sub directory named `master`. 

 For a multi-level project, the subprojects are named based on their sub directories, and it should match the values from the `include` block of the parent's `settings.gradle`.

![image](https://user-images.githubusercontent.com/26146482/72160106-c7931f80-338b-11ea-879e-bfbcdd69c0ce.png)


The possible commands for a Gradle project are:
1. `Start` - runs `gradle libertyDev -b={path to build.gradle}`
2. `Start...` - runs `gradle libertyDev --{custom parameter} -b={path to build.gradle}`
3. `Stop`- behaves the same as the Maven command
4. `Run tests` - behaves the same as the Maven command
5. `View test report` (see #23)
