### PR TITLE
Refresh dev explorer view when files are modified/added/deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,14 @@
 	],
 	"keywords": [
 		"Java",
-		"Open Liberty"
+		"Open Liberty",
+		"Maven",
+		"Gradle"
 	],
 	"icon": "images/ol_logo.png",
 	"activationEvents": [
+		"workspaceContains:**/pom.xml",
+		"workspaceContains:**/build.gradle",
 		"onCommand:liberty.dev.start",
 		"onCommand:liberty.dev.stop",
 		"onCommand:liberty.dev.custom",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		if (vscode.workspace.workspaceFolders !== undefined) {
 			const projectProvider = new ProjectProvider(vscode.workspace.workspaceFolders, allPomPaths, allGradlePaths);
+			registerFileWatcher(projectProvider);
 			vscode.window.registerTreeDataProvider('liberty-dev', projectProvider);
 			vscode.workspace.onDidChangeTextDocument((e) => {
 				pomPaths.forEach((pom) => {
@@ -65,3 +66,19 @@ export async function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
 }
 
+/**
+ * File Watcher to prompt the dev explorer to refresh on file changes
+ * @param projectProvider Liberty Dev projects
+ */
+export function registerFileWatcher(projectProvider: ProjectProvider): void {
+	const watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher('{**/pom.xml,**/build.gradle,**/settings.gradle}');
+	watcher.onDidCreate(async (e: vscode.Uri) => {
+		projectProvider.refresh();
+	});
+	watcher.onDidChange(async (e: vscode.Uri) => {
+		projectProvider.refresh();
+	});
+	watcher.onDidDelete(async (e: vscode.Uri) => {
+		projectProvider.refresh();
+	});
+}

--- a/src/utils/GradleUtil.ts
+++ b/src/utils/GradleUtil.ts
@@ -21,7 +21,6 @@ export function validGradleBuild(buildFile: any) {
                 var dependency = buildFile.buildscript.dependencies[i];
                 // check that group matches io.openliberty.tools and name matches liberty-gradle-plugin
                 if (dependency.group == "io.openliberty.tools" && dependency.name == "liberty-gradle-plugin") {
-                    console.debug("Found liberty-gradle-plugin in the build.gradle");
                     return true;
                 }
             }

--- a/src/utils/MavenUtil.ts
+++ b/src/utils/MavenUtil.ts
@@ -115,7 +115,6 @@ function mavenPluginDetected(build: { plugins: { plugin: any; }[]; }[] | undefin
                     if (plugin !== undefined) {
                         for (var k = 0; k < plugin.length; k++) {
                             if (plugin[k].artifactId[0] === "liberty-maven-plugin" && plugin[k].groupId[0] === "io.openliberty.tools") {
-                                console.debug("Found liberty-maven-plugin in the pom.xml");
                                 return true;
                             }
                             if (plugin[k].artifactId[0] === "boost-maven-plugin" && plugin[k].groupId[0] === "org.microshed.boost") {


### PR DESCRIPTION
Fix for #24 

Using a file watcher monitor `pom.xml`, `build.gradle` and `settings.gradle` files for modifications.  Prompt the Liberty Dev explorer view to refresh on detected changes.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>