### PR TITLE
Delete terminals when closed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('liberty.dev.open.gradle.test.report', async (libProject?: LibertyProject | undefined) => devCommands.openReport('gradle', libProject))
 	);
+	context.subscriptions.push(
+		vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {
+			devCommands.deleteTerminal(closedTerminal);
+		})
+	);
 }
 
 // this method is called when your extension is deactivated

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -6,7 +6,7 @@ import * as Path from 'path';
 
 import { getReport } from './Util';
 
-export const terminals: { [libProjectId: string]: LibertyProject } = {};
+export const terminals: { [libProjectId: number]: LibertyProject } = {};
 
 // opens pom associated with LibertyProject and starts dev mode
 export async function openProject(pomPath: string): Promise<void> {
@@ -21,7 +21,9 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
         var terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
-            terminals[libProject.getLabel() + " (liberty:dev)"] = libProject;
+            if (terminal !== undefined) {
+                terminals[Number(terminal.processId)] = libProject;
+            }
         }
         if (terminal !== undefined) {
             terminal.show();
@@ -61,7 +63,9 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
         var terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
-            terminals[libProject.getLabel() + " (liberty:dev)"] = libProject;
+            if (terminal !== undefined) {
+                terminals[Number(terminal.processId)] = libProject;
+            }
         }
         if (terminal !== undefined) {
             terminal.show();
@@ -159,7 +163,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
 // retrieve LibertyProject correpsonding to closed terminal and delete terminal
 export function deleteTerminal(terminal: vscode.Terminal): void {
     try {
-        let libProject = terminals[terminal.name];
+        let libProject = terminals[Number(terminal.processId)];
         libProject.deleteTerminal();
     } catch {
         console.error("Unable to delete terminal: " + terminal.name);

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -6,6 +6,8 @@ import * as Path from 'path';
 
 import { getReport } from './Util';
 
+export const terminals: { [libProjectId: string]: LibertyProject } = {};
+
 // opens pom associated with LibertyProject and starts dev mode
 export async function openProject(pomPath: string): Promise<void> {
     console.log("Opening " + pomPath);
@@ -19,6 +21,7 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
         var terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
+            terminals[libProject.getLabel() + " (liberty:dev)"] = libProject;
         }
         if (terminal !== undefined) {
             terminal.show();
@@ -58,6 +61,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
         var terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
+            terminals[libProject.getLabel() + " (liberty:dev)"] = libProject;
         }
         if (terminal !== undefined) {
             terminal.show();
@@ -149,5 +153,15 @@ export async function openReport(reportType: string, libProject?: LibertyProject
         }
     } else {
         console.error("Cannot open test reports on an undefined project");
+    }
+}
+
+// retrieve LibertyProject correpsonding to closed terminal and delete terminal
+export function deleteTerminal(terminal: vscode.Terminal): void {
+    try {
+        let libProject = terminals[terminal.name];
+        libProject.deleteTerminal();
+    } catch {
+        console.error("Unable to delete terminal: " + terminal.name);
     }
 }

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -49,7 +49,6 @@ export class ProjectProvider implements vscode.TreeDataProvider<LibertyProject> 
 				projects.push(await project);
 				validPoms.push(parentPom);
 			}
-
 		}
 
 		// check poms
@@ -161,6 +160,10 @@ export class LibertyProject extends vscode.TreeItem {
 			return terminal;
 		}
 		return undefined;
+	}
+
+	public deleteTerminal(): void {
+		delete this.terminal;
 	}
 }
 


### PR DESCRIPTION
Fix for #32 

Track terminals that have been created and the projects they correspond to. When a terminal is closed, delete the corresponding terminal.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>