### PR TITLE
Require semicolon

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,8 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
+    "@typescript-eslint/semi": "warn",
+    "eqeqeq": "warn",
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "quotes": [


### PR DESCRIPTION
Require semicolon and strict equality checks rules that were missed when moving to eslint