### PR TITLE
Reordered commands in dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,31 +92,38 @@
 			"view/item/context": [
 				{
 					"command": "liberty.dev.start",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"group": "libertyCore@1"
 				},
 				{
 					"command": "liberty.dev.stop",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"group": "libertyCore@3"
 				},
 				{
 					"command": "liberty.dev.custom",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"group": "libertyCore@2"
 				},
 				{
 					"command": "liberty.dev.run.tests",
-					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject"
+					"when": "viewItem == libertyMavenProject || viewItem == libertyGradleProject",
+					"group": "libertyCore@4"
 				},
 				{
 					"command": "liberty.dev.open.failsafe.report",
-					"when": "viewItem == libertyMavenProject"
+					"when": "viewItem == libertyMavenProject",
+					"group": "libertyCore@5"
 				},
 				{
 					"command": "liberty.dev.open.surefire.report",
-					"when": "viewItem == libertyMavenProject"
+					"when": "viewItem == libertyMavenProject",
+					"group": "libertyCore@6"
 				},
 				{
 					"command": "liberty.dev.open.gradle.test.report",
-					"when": "viewItem == libertyGradleProject"
+					"when": "viewItem == libertyGradleProject",
+					"group": "libertyCore@5"
 				}
 			],
 			"commandPalette": [

--- a/src/utils/GradleUtil.ts
+++ b/src/utils/GradleUtil.ts
@@ -35,7 +35,7 @@ export function validGradleBuild(buildFile: any): boolean {
  * Else return the parent directory name of the build.gradle
  * @param path build.gradle location
  */
-export async function getGradleProjetName(gradlePath: string): Promise<string> {
+export async function getGradleProjectName(gradlePath: string): Promise<string> {
     const dirName = path.dirname(gradlePath);
     const gradleSettings = getGradleSettings(gradlePath);
     let label = path.basename(dirName);

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -17,7 +17,7 @@ export async function openProject(pomPath: string): Promise<void> {
 // start dev mode
 export async function startDevMode(libProject?: LibertyProject | undefined): Promise<void> {
     if (libProject !== undefined) {
-        console.log("Starting liberty:dev on " + libProject.getLabel());
+        console.log("Starting liberty dev on " + libProject.getLabel());
         let terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
@@ -35,30 +35,30 @@ export async function startDevMode(libProject?: LibertyProject | undefined): Pro
             }
         }
     } else {
-        console.error("Cannot start liberty:dev on an undefined project");
+        console.error("Cannot start liberty dev on an undefined project");
     }
 }
 
 // stop dev mode
 export async function stopDevMode(libProject?: LibertyProject | undefined): Promise<void> {
     if (libProject !== undefined) {
-        console.log("Stopping liberty:dev on " + libProject.getLabel());
+        console.log("Stopping liberty dev on " + libProject.getLabel());
         const terminal = libProject.getTerminal();
         if (terminal !== undefined) {
             terminal.show();
             terminal.sendText("exit"); // stop dev mode on current project
         } else {
-            vscode.window.showWarningMessage("liberty:dev has not been started on " + libProject.getLabel());
+            vscode.window.showWarningMessage("liberty dev has not been started on " + libProject.getLabel());
         }
     } else {
-        console.error("Cannot stop liberty:dev on an undefined project");
+        console.error("Cannot stop liberty dev on an undefined project");
     }
 }
 
 // custom start dev mode command
 export async function customDevMode(libProject?: LibertyProject | undefined): Promise<void> {
     if (libProject !== undefined) {
-        console.log("Starting liberty:dev with custom parameters on " + libProject.getLabel());
+        console.log("Starting liberty dev with custom parameters on " + libProject.getLabel());
         let terminal = libProject.getTerminal();
         if (terminal === undefined) {
             terminal = libProject.createTerminal();
@@ -88,7 +88,7 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
             },
                 {
                     placeHolder: placeHolderStr,
-                    prompt: "Specify custom parameters for the liberty:dev command.",
+                    prompt: "Specify custom parameters for the liberty dev command.",
                     ignoreFocusOut: true,
                 },
             ));
@@ -101,20 +101,20 @@ export async function customDevMode(libProject?: LibertyProject | undefined): Pr
             }
         }
     } else {
-        console.error("Cannot custom start liberty:dev on an undefined project");
+        console.error("Cannot custom start liberty dev on an undefined project");
     }
 }
 
 // run tests on dev mode
 export async function runTests(libProject?: LibertyProject | undefined): Promise<void> {
     if (libProject !== undefined) {
-        console.log("Running liberty:dev tests on " + libProject.getLabel());
+        console.log("Running liberty dev tests on " + libProject.getLabel());
         const terminal = libProject.getTerminal();
         if (terminal !== undefined) {
             terminal.show();
             terminal.sendText(" "); // sends Enter to run tests in terminal
         } else {
-            vscode.window.showWarningMessage("liberty:dev has not been started on " + libProject.getLabel());
+            vscode.window.showWarningMessage("liberty dev has not been started on " + libProject.getLabel());
         }
     } else {
         console.error("Cannot run tests on an undefined project");
@@ -156,7 +156,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
     }
 }
 
-// retrieve LibertyProject correpsonding to closed terminal and delete terminal
+// retrieve LibertyProject corresponding to closed terminal and delete terminal
 export function deleteTerminal(terminal: vscode.Terminal): void {
     try {
         const libProject = terminals[Number(terminal.processId)];

--- a/src/utils/libertyProject.ts
+++ b/src/utils/libertyProject.ts
@@ -218,7 +218,7 @@ export class LibertyProject extends vscode.TreeItem {
 					env = { JAVA_HOME: javaHome };
 				}
 			}
-			const terminal = vscode.window.createTerminal({ name: this.label + " (liberty:dev)", env });
+			const terminal = vscode.window.createTerminal({ name: this.label + " (liberty dev)", env });
 			return terminal;
 		}
 		return undefined;
@@ -242,7 +242,7 @@ export async function createProject(buildFile: string, contextValue: string, xml
 			}
 		});
 	} else {
-		label = await gradleUtil.getGradleProjetName(buildFile);
+		label = await gradleUtil.getGradleProjectName(buildFile);
 	}
 	const project: LibertyProject = new LibertyProject(label, vscode.TreeItemCollapsibleState.None, buildFile, "start", contextValue, undefined, {
 		command: "extension.open.project",


### PR DESCRIPTION
1. Reordered commands in dashboard so that they appear in logical order:
![image](https://user-images.githubusercontent.com/26146482/73307974-404c0580-41ed-11ea-97fa-ac42905e11a2.png)

2. Changed logs and terminal name from `liberty:dev` to `liberty dev` so that it is not Maven specific.

3. Fixed typo in `getGradleProjectName` method

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>