### PR TITLE
detect custom test report locations

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,3 @@
 export const LIBERTY_MAVEN_PROJECT = "libertyMavenProject";
 export const LIBERTY_GRADLE_PROJECT = "libertyGradleProject";
+export const TEST_REPORT_STRING = "Test Summary";

--- a/src/utils/devCommands.ts
+++ b/src/utils/devCommands.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { LibertyProject } from "./libertyProject";
 import { getReport } from "./Util";
 import { LIBERTY_MAVEN_PROJECT, LIBERTY_GRADLE_PROJECT } from "./constants";
+import { getGradleTestReport } from "./GradleUtil";
 
 export const terminals: { [libProjectId: number]: LibertyProject } = {};
 
@@ -131,7 +132,7 @@ export async function openReport(reportType: string, libProject?: LibertyProject
             if (libProject.getContextValue() === LIBERTY_MAVEN_PROJECT) {
                 report = Path.join(workspaceFolder.uri.fsPath, "target", "site", reportType + "-report.html");
             } else if (libProject.getContextValue() === LIBERTY_GRADLE_PROJECT) {
-                report = Path.join(workspaceFolder.uri.fsPath, "build", "reports", "tests", "test", "index.html");
+                report = await getGradleTestReport(libProject.path, workspaceFolder);
             }
             let reportTypeLabel = reportType;
             if (reportType === "gradle") {


### PR DESCRIPTION
Fix for #23 
Try to resolve custom test report locations.  If cannot resolve, search the workspace for `index.html` files that include `Test Summary`.  Use the most recently modified file.

If cannot find the above or there is not a custom test report location in the `build.gradle`, use the default `build/reports/tests/test/index.html`

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>